### PR TITLE
Corregido error en ejercicio 28 que generaba 2 unclosed div

### DIFF
--- a/espacios-vectoriales.md
+++ b/espacios-vectoriales.md
@@ -3532,7 +3532,6 @@ y finalmente, obtenemos la base de $U\cap W$: $\{ (1,4,1,0)\}$
 
 En el espacio vectorial $V$, $B=\{ e_1,e_2\}$ es una base. Calcula las coordenadas respecto de la base  $B'=\{e_1+e_2, 2e_1-e_2\}$ del vector $v=(1,-1)_{B}$.
 
-
 :::: {.callout collapse="true" title="Solución"}
 
 Como $B'=\{(1,1)_B, (2,-1)_B\}$, planteamos 
@@ -3547,7 +3546,7 @@ $$
 \left\{ \begin{array}{l}
 a+2b=1,\\
 a-b=-1.
-\end{array}\right.\sim_f  \left\{ \begin{array}{l}
+\end{array}\right.\sim_f \left\{ \begin{array}{l}
 a=-1/3,\\
 b=2/3.
 \end{array}\right.
@@ -3578,8 +3577,8 @@ $$
 
 Así las cartesianas de $U$ son
 $\left\{\begin{array}{l}
-a_1=0,\\
-a_3=0.
+a_1=0\\
+a_3=0
 \end{array}\right.$ Y una base $\{1,x^2\}$.
 
 $$
@@ -3587,22 +3586,11 @@ p(x)=(a_0,a_1,a_2,a_3)_{B_s}=(-a_0,a_1,-a_2,a_3)_{B_s}=-p(-x),
 $$
 
 nos da que las cartesianas de $W$ son $\left\{\begin{array}{l}
-a_0=0,\\
-a_2=0.
-\end{array}\right.$  Y una base $\{x,x^3\}$.
+a_0=0\\
+a_2=0
+\end{array}\right.$ Y una base $\{x,x^3\}$.
 
 Así que un sistema de generadores de $U+W$ es $\{1,x,x^2,x^3\}$ con lo que $U+W=\mathcal{P}_3(\mathbb{R})$, y además de que porque estos polinomios son linealmente independientes, se puede razonar con la fórmula de las dimensiones que $U\cap W=0$, con lo que se obtiene $\mathcal{P}_3(\mathbb{R})= U\oplus W$.
-</li>
-
-<li>Descomponer el vector $3x^3+x-2$ como suma de un vector en $U$ y otro en $W$.
-
-Es inmediato que 
-
-$$
-3x^3+x-2= (-2) + (x+3x^3)
-$$
-
-y el primer polinomio está en $U$ y el segundo en $W$.
 
 ::::
 :::::


### PR DESCRIPTION
En teoría el warning ya no aparece, me había dejado sin borrar código de un apartado del ejercicio que había que eliminar.

Buen fin de semana Pedro